### PR TITLE
Fix cuda arguments for cpu-only device

### DIFF
--- a/ezgeno/utils.py
+++ b/ezgeno/utils.py
@@ -6,12 +6,12 @@ import torch.nn.init as init
 from torch.autograd import Variable
 from collections import defaultdict
 
-def get_variable(inputs, cuda=False, **kwargs):
+def get_variable(inputs, cuda=-1, **kwargs):
     if type(inputs) in [list, np.ndarray]:
         inputs = torch.Tensor(inputs)
         
     if cuda==-1:
-        out = Variable(inputs.cuda(), **kwargs)
+        out = Variable(inputs, **kwargs)
     else:
         out = Variable(inputs.to('cuda:%d'%cuda), **kwargs)
     return out

--- a/ezgeno/visualize.py
+++ b/ezgeno/visualize.py
@@ -215,7 +215,7 @@ def show_grad_cam(args, model_path, data_name, model, use_cuda, window=9):
     #test_data = testset(args.dataSource,testLabelPath,testFileList)
     seq_length = test_data.seq_length
     test_loader = torch.utils.data.DataLoader(test_data, batch_size=1, num_workers=8)
-    grad_cam = GradCam(model=model, target_layer_names=args.target_layer_names, seq_length=seq_length, use_cuda=True)
+    grad_cam = GradCam(model=model, target_layer_names=args.target_layer_names, seq_length=seq_length, use_cuda=use_cuda)
     target_index = None
     
     pred_list = []


### PR DESCRIPTION
I got cuda error when running ezGeno in non-gpu server,
even when I set `--use_cuda=False` or  removing `--cuda 0`

Some parameters is hard coded or added `.cuda()` when cpu-only mode is on,
and here are my minor patch to run it successfully.
